### PR TITLE
Better spacing around paragraphs

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -16,7 +16,10 @@ body {
 }
 p {
   line-height: 1.5;
-  margin: 30px 0;
+  margin: 6px 0;
+}
+p + p {
+    margin: 24px 0 6px 0;
 }
 p a {
   /* text-decoration: underline */
@@ -612,12 +615,12 @@ footer .theme-by {
 }
 
 .pager.blog-pager {
-  margin-top: 0;
+  margin-top:10px;
 }
 
 @media only screen and (min-width: 768px) {
   .pager.blog-pager  {
-    margin-top: 10px;
+    margin-top: 40px;
   }
 }
 


### PR DESCRIPTION
This adjusts a few spacings so that the large space between paragraphs only shows up between subsequent paragraphs, not before all paragraphs. Makes things like code boxes much nicer.

(Also added a bit more space above the next/previous buttons)

You can see an example of the new spacing and other changes here: https://iscinumpy.gitlab.io

(The only change I've not made a PR for is the archive listing; it's not quite ideal and general, though if someone is interested in working on it, my source is available.)